### PR TITLE
Better exceptions handling

### DIFF
--- a/tinvest/__init__.py
+++ b/tinvest/__init__.py
@@ -1,5 +1,6 @@
 from .apis import MarketApi, OperationsApi, OrdersApi, PortfolioApi, SandboxApi
 from .async_client import AsyncClient
+from .errors import StartupError
 from .shemas import (
     Candle,
     CandleResolution,
@@ -104,4 +105,5 @@ __all__ = (
     'InstrumentInfoStreamingSchema',
     'OrderbookStreamingSchema',
     'ErrorStreamingSchema',
+    'StartupError',
 )

--- a/tinvest/errors.py
+++ b/tinvest/errors.py
@@ -1,0 +1,2 @@
+class StartupError(Exception):
+    pass


### PR DESCRIPTION
На текущий момент, если возникает exception в любом из хендлеров — это вызовет реконнект по вебсокету.
Помимо этого при реконнекте лучше использовать свежую сессию т.к. старая могла закрыться.